### PR TITLE
Extend --strip test to expose a failure

### DIFF
--- a/t/test.sh
+++ b/t/test.sh
@@ -360,6 +360,20 @@ WVPASSEQ "$(bup ls strip/latest/)" "a
 b
 d/
 f"
+bup tick
+WVPASS bup index -ux $D
+bup save --strip -n strip $D
+WVPASSEQ "$(bup ls strip/latest/)" "a
+b
+d/
+f"
+bup tick
+WVPASS bup index -ux $D
+bup save --strip -n strip $D
+WVPASSEQ "$(bup ls strip/latest/)" "a
+b
+d/
+f"
 
 WVSTART "strip-path"
 D=strip-path.tmp


### PR DESCRIPTION
I noticed some oddities with incremental backups where --strip or --strip-path were involved with 'bup save'. This change extends the 'strip' test by doing two gratuitous index/save cycles after the initial save, which ends up with the latest version of the backup being empty and thus exposes a bug.

It seems to me that the problem is somewhere around lines 234--248 of cmd/save-cmd.py, where after mangling the directory using --strip, --strip-path or --graft the original 'ent' is used to validate trees, but my understanding of that part of the code isn't sufficient to allow me a quick fix.
