### PR TITLE
Dont hide errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 bup: It backs things up
 =======================
 
@@ -93,15 +92,15 @@ From source
 
  - Install the needed python libraries (including the development
    libraries).  On Debian or Ubuntu, this is usually:
-        apt-get install python2.6-dev python-fuse
-        apt-get install python-pyxattr python-pylibacl
-        
+
+        apt-get install python2.6-dev python-fuse python-pyxattr python-pylibacl
+
     Substitute python2.5-dev or python2.4-dev if you have an older system.
-    
+
     Or on newer Debian/Ubuntu versions, you can try this:
-    
+
         apt-get build-dep bup
-   	
+
  - Build the python module and symlinks:
  
         make

--- a/main.py
+++ b/main.py
@@ -172,7 +172,8 @@ try:
             # shortcut when no bup-newliner stuff is needed
             os.execvp(c[0], c)
         else:
-            p = subprocess.Popen(c, stdout=outf, stderr=errf,
+            # Make sure to print stderr so that the user can see e.g. SSH errors.
+            p = subprocess.Popen(c, stdout=outf, stderr=None,
                                  preexec_fn=force_tty)
         while 1:
             # if we get a signal while waiting, we have to keep waiting, just

--- a/main.py
+++ b/main.py
@@ -146,11 +146,9 @@ if fix_stdout or fix_stderr:
                          close_fds=True, preexec_fn=force_tty)
     os.close(drealf)
     outf = fix_stdout and n.stdin.fileno() or None
-    errf = fix_stderr and n.stdin.fileno() or None
 else:
     n = None
     outf = None
-    errf = None
 
 
 class SigException(Exception):
@@ -168,7 +166,7 @@ p = None
 try:
     try:
         c = (do_profile and [sys.executable, '-m', 'cProfile'] or []) + subcmd
-        if not n and not outf and not errf:
+        if not n and not outf:
             # shortcut when no bup-newliner stuff is needed
             os.execvp(c[0], c)
         else:


### PR DESCRIPTION
Bup's newliner hides critical error messages (such as SSH authentication failures).

This patch makes them visible by not piping stderr through the newliner.

As the newliner is there to make beautiful status lines and you won't get status anyway if you have a critical error, this should not influence the everything-is-working-all-right case.

(And usually if an error occurs, you would care more about being able to see the error message than a nice status anyway.)

All tests pass.
