### PR TITLE
fix `excluded_paths` argument to drecurse

### DIFF
--- a/cmd/drecurse-cmd.py
+++ b/cmd/drecurse-cmd.py
@@ -19,7 +19,7 @@ if len(extra) != 1:
 
 excluded_paths = drecurse.parse_excludes(flags)
 
-it = drecurse.recursive_dirlist(extra, opt.xdev, excluded_paths)
+it = drecurse.recursive_dirlist(extra, opt.xdev, excluded_paths=excluded_paths)
 if opt.profile:
     import cProfile
     def do_it():


### PR DESCRIPTION
`drecurse.recursive_dirlist` has `excluded_paths` as _4th_ positional argument. Better to pass it as keyword argument.
