### PR TITLE
Resolve symlinks with argv[0]/exe.

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 import sys, os, subprocess, signal, getopt
 
 argv = sys.argv
-exe = argv[0]
+exe = os.path.realpath(argv[0])
 exepath = os.path.split(exe)[0] or '.'
 exeprefix = os.path.split(os.path.abspath(exepath))[0]
 


### PR DESCRIPTION
When using a symlink to access bup, this needs to be resolved to
make the PYTHONPATH adjustment work properly.
